### PR TITLE
GOSRV-3 - Add store binding

### DIFF
--- a/gowebserver.go
+++ b/gowebserver.go
@@ -5,6 +5,7 @@ import (
     "github.com/coda-it/gowebserver/router"
     "github.com/coda-it/gowebserver/session"
     "github.com/coda-it/gowebserver/utils/logger"
+	"github.com/coda-it/gowebserver/store"
 )
 
 type WebServerOptions struct {

--- a/gowebserver.go
+++ b/gowebserver.go
@@ -5,7 +5,6 @@ import (
     "github.com/coda-it/gowebserver/router"
     "github.com/coda-it/gowebserver/session"
     "github.com/coda-it/gowebserver/utils/logger"
-	"github.com/coda-it/gowebserver/store"
 )
 
 type WebServerOptions struct {
@@ -48,6 +47,6 @@ func (s *WebServer) Run() bool {
 	return true
 }
 
-func (s *WebServer) AddDataSource(name string, ds store.IDataSource) {
+func (s *WebServer) AddDataSource(name string, ds interface{}) {
 	s.Router.AddDataSource(name, ds)
 }

--- a/gowebserver.go
+++ b/gowebserver.go
@@ -46,3 +46,7 @@ func (s *WebServer) Run() bool {
 
 	return true
 }
+
+func (s *WebServer) AddDataSource(name string, ds store.IDataSource) {
+	s.Router.AddDataSource(name, ds)
+}

--- a/router/route.go
+++ b/router/route.go
@@ -3,13 +3,14 @@ package router
 import (
     "net/http"
     "github.com/coda-it/gowebserver/session"
+    "github.com/coda-it/gowebserver/store"
 )
 
 type UrlOptions struct {
     Params map[string]string
 }
 
-type ControllerHandler func(http.ResponseWriter, *http.Request, UrlOptions, session.ISessionManager)
+type ControllerHandler func(http.ResponseWriter, *http.Request, UrlOptions, session.ISessionManager, store store.IStore)
 
 type UrlRoute struct {
     urlRegExp       string

--- a/router/route.go
+++ b/router/route.go
@@ -10,7 +10,7 @@ type UrlOptions struct {
     Params map[string]string
 }
 
-type ControllerHandler func(http.ResponseWriter, *http.Request, UrlOptions, session.ISessionManager, store.Store)
+type ControllerHandler func(http.ResponseWriter, *http.Request, UrlOptions, session.ISessionManager, store.IStore)
 
 type UrlRoute struct {
     urlRegExp       string

--- a/router/route.go
+++ b/router/route.go
@@ -10,7 +10,7 @@ type UrlOptions struct {
     Params map[string]string
 }
 
-type ControllerHandler func(http.ResponseWriter, *http.Request, UrlOptions, session.ISessionManager, store store.IStore)
+type ControllerHandler func(http.ResponseWriter, *http.Request, UrlOptions, session.ISessionManager, store.Store)
 
 type UrlRoute struct {
     urlRegExp       string

--- a/router/router.go
+++ b/router/router.go
@@ -19,7 +19,7 @@ type Router struct {
     sessionManager		session.ISessionManager
     urlRoutes 			[]UrlRoute
     pageNotFoundController	ControllerHandler
-    store			store.Store
+    store			store.IStore
 }
 
 func New(sm session.SessionManager, notFound ControllerHandler) Router {
@@ -95,6 +95,6 @@ func (router *Router) AddRoute(urlPattern string, pathHandler ControllerHandler)
 	})
 }
 
-func (router *Router) AddDataSource(name string, ds store.IDataSource) {
+func (router *Router) AddDataSource(name string, ds interface{}) {
 	router.store.AddDataSource(name, ds)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/coda-it/gowebserver/utils/url"
 	"github.com/coda-it/gowebserver/utils/logger"
 	"github.com/coda-it/gowebserver/session"
+	"github.com/coda-it/gowebserver/store
 )
 
 type IRouter interface {
@@ -15,9 +16,10 @@ type IRouter interface {
 }
 
 type Router struct {
-	sessionManager			session.ISessionManager
+    sessionManager			session.ISessionManager
     urlRoutes 				[]UrlRoute
     pageNotFoundController	ControllerHandler
+    stores			map[string]store.IStore
 }
 
 func New(sm session.SessionManager, notFound ControllerHandler) Router {
@@ -65,7 +67,7 @@ func (router *Router) Route(w http.ResponseWriter, r *http.Request)  {
         route.urlRegExp)
 
 	routeHandler := route.handler
-	routeHandler(w, r, *urlOptions, router.sessionManager)
+	routeHandler(w, r, *urlOptions, router.sessionManager, router.stores)
 }
 
 func (router *Router) AddRoute(urlPattern string, pathHandler ControllerHandler) {
@@ -91,4 +93,8 @@ func (router *Router) AddRoute(urlPattern string, pathHandler ControllerHandler)
 		handler: pathHandler,
 		params: params,
 	})
+}
+
+func (r *Router) AddDataSource(name string, ds store.IDataSource) {
+	r.stores[name] = ds
 }

--- a/router/router.go
+++ b/router/router.go
@@ -7,7 +7,7 @@ import (
 	"github.com/coda-it/gowebserver/utils/url"
 	"github.com/coda-it/gowebserver/utils/logger"
 	"github.com/coda-it/gowebserver/session"
-	"github.com/coda-it/gowebserver/store
+	"github.com/coda-it/gowebserver/store"
 )
 
 type IRouter interface {
@@ -16,17 +16,18 @@ type IRouter interface {
 }
 
 type Router struct {
-    sessionManager			session.ISessionManager
-    urlRoutes 				[]UrlRoute
+    sessionManager		session.ISessionManager
+    urlRoutes 			[]UrlRoute
     pageNotFoundController	ControllerHandler
-    stores			map[string]store.IStore
+    store			store.Store
 }
 
 func New(sm session.SessionManager, notFound ControllerHandler) Router {
 	return Router{
-		sm,
-		make([]UrlRoute, 0),
-		notFound,
+		sessionManager: sm,
+		urlRoutes: make([]UrlRoute, 0),
+		pageNotFoundController: notFound,
+		store: store.New(),
 	}
 }
 
@@ -67,11 +68,10 @@ func (router *Router) Route(w http.ResponseWriter, r *http.Request)  {
         route.urlRegExp)
 
 	routeHandler := route.handler
-	routeHandler(w, r, *urlOptions, router.sessionManager, router.stores)
+	routeHandler(w, r, *urlOptions, router.sessionManager, router.store)
 }
 
 func (router *Router) AddRoute(urlPattern string, pathHandler ControllerHandler) {
-
 	params := make(map[string]int)
 	pathRegExp := url.UrlPatternToRegExp(urlPattern)
 
@@ -95,6 +95,6 @@ func (router *Router) AddRoute(urlPattern string, pathHandler ControllerHandler)
 	})
 }
 
-func (r *Router) AddDataSource(name string, ds store.IDataSource) {
-	r.stores[name] = ds
+func (router *Router) AddDataSource(name string, ds store.IDataSource) {
+	router.store.AddDataSource(name, ds)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1,31 +1,24 @@
 package store
 
 type IStore interface {
-	Add(string, string, string)
-	Get(string, string) string
-}
-
-type IDataSource interface {
-	Add(string, string)
-	Get(string) string
+	AddDataSource(string, interface{})
+	GetDataSource(string) interface{}
 }
 
 type Store struct {
-	dataSources	map[string]IDataSource
+	dataSources	map[string]interface{}
 }
 
 func New() Store {
-	return Store{}
+	return Store{
+		dataSources: make(map[string]interface{}),
+	}
 }
 
-func (s *Store) AddDataSource(name string, ds IDataSource) {
+func (s Store) AddDataSource(name string, ds interface{}) {
 	s.dataSources[name] = ds
 }
 
-func (s *Store) Add(collection string, key string, value string) {
-	s.dataSources[collection].Add(key, value)
-}
-
-func (s* Store) Get(collection string, key string) string {
-	return s.dataSources[collection].Get(key)
+func (s Store) GetDataSource(collection string) interface{} {
+	return s.dataSources[collection]
 }

--- a/store/store.go
+++ b/store/store.go
@@ -14,6 +14,14 @@ type Store struct {
 	dataSources	map[string]IDataSource
 }
 
+func New() Store {
+	return Store{}
+}
+
+func (s *Store) AddDataSource(name string, ds IDataSource) {
+	s.dataSources[name] = ds
+}
+
 func (s *Store) Add(collection string, key string, value string) {
 	s.dataSources[collection].Add(key, value)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1,0 +1,23 @@
+package store
+
+type IStore interface {
+	Add(string, string, string)
+	Get(string, string) string
+}
+
+type IDataSource interface {
+	Add(string, string)
+	Get(string) string
+}
+
+type Store struct {
+	dataSources	map[string]IDataSource
+}
+
+func (s *Store) Add(collection string, key string, value string) {
+	s.dataSources[collection].Add(key, value)
+}
+
+func (s* Store) Get(collection string, key string) string {
+	return s.dataSources[collection].Get(key)
+}


### PR DESCRIPTION
**Business justification:** In packages using `gowebserver` there was a need of adding variety of stores to the routing handlers.

**Description:** Implement possibility to add key-value stores of non defined type (`interface{}`) which can server as generic stores.